### PR TITLE
fix: check stderr for auth errors; support longer YouTube videos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,8 @@ SURPRIDE_WEBHOOK_TOKEN=
 
 # === YouTube / yt-dlp ===
 YTDLP_COOKIES_FILE=              # Path to Netscape-format cookies.txt for YouTube auth
+YTDLP_TIMEOUT_MS=600000          # yt-dlp download timeout in ms (default: 600000 = 10 min)
+FFMPEG_TIMEOUT_MS=300000          # ffmpeg extraction timeout in ms (default: 300000 = 5 min)
 
 # === Environment ===
 NODE_ENV=development

--- a/packages/core/src/providers/groq-whisper.ts
+++ b/packages/core/src/providers/groq-whisper.ts
@@ -1,5 +1,9 @@
-import { readFile, stat } from "node:fs/promises";
-import { basename } from "node:path";
+import { readFile, stat, unlink } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 
 export interface TranscriptionSegment {
   start: number;
@@ -14,6 +18,7 @@ export interface TranscriptionResult {
 }
 
 const MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024; // 25MB Groq limit
+const CHUNK_TARGET_BYTES = 24 * 1024 * 1024;  // 24MB target per chunk (safe margin)
 
 export class GroqWhisperClient {
   private apiKey: string;
@@ -29,13 +34,16 @@ export class GroqWhisperClient {
 
   async transcribe(audioPath: string, language = "en"): Promise<TranscriptionResult> {
     const fileStats = await stat(audioPath);
-    if (fileStats.size > MAX_FILE_SIZE_BYTES) {
-      throw new Error(
-        `Audio file too large (${Math.round(fileStats.size / 1024 / 1024)}MB). ` +
-        `Groq Whisper limit is 25MB. Try a shorter video (<30 min).`,
-      );
+
+    if (fileStats.size <= MAX_FILE_SIZE_BYTES) {
+      return this.transcribeSingle(audioPath, language);
     }
 
+    // File too large — split into chunks and transcribe each
+    return this.transcribeChunked(audioPath, fileStats.size, language);
+  }
+
+  private async transcribeSingle(audioPath: string, language: string): Promise<TranscriptionResult> {
     const formData = new FormData();
     const fileBuffer = await readFile(audioPath);
     const fileBlob = new Blob([fileBuffer.buffer as ArrayBuffer], { type: "audio/mpeg" });
@@ -72,6 +80,85 @@ export class GroqWhisperClient {
         text: s.text.trim(),
       })),
       durationSeconds: data.duration,
+    };
+  }
+
+  private async transcribeChunked(
+    audioPath: string,
+    fileSize: number,
+    language: string,
+  ): Promise<TranscriptionResult> {
+    // Get total duration with ffprobe
+    const { stdout: durationStr } = await execFileAsync("ffprobe", [
+      "-v", "error",
+      "-show_entries", "format=duration",
+      "-of", "default=noprint_wrappers=1:nokey=1",
+      audioPath,
+    ]);
+    const totalDuration = parseFloat(durationStr.trim()) || 0;
+    if (totalDuration === 0) {
+      throw new Error("Could not determine audio duration for chunked transcription.");
+    }
+
+    // Calculate chunk duration based on file size ratio
+    const numChunks = Math.ceil(fileSize / CHUNK_TARGET_BYTES);
+    const chunkDuration = Math.ceil(totalDuration / numChunks);
+
+    // Split into chunks using ffmpeg
+    const dir = dirname(audioPath);
+    const base = basename(audioPath, ".mp3");
+    const chunkPaths: string[] = [];
+
+    for (let i = 0; i < numChunks; i++) {
+      const startSec = i * chunkDuration;
+      const chunkPath = join(dir, `${base}_chunk${i}.mp3`);
+      chunkPaths.push(chunkPath);
+
+      await execFileAsync("ffmpeg", [
+        "-i", audioPath,
+        "-ss", String(startSec),
+        "-t", String(chunkDuration),
+        "-vn",
+        "-ab", "128k",
+        "-ar", "44100",
+        "-y",
+        chunkPath,
+      ], { timeout: 120_000 });
+    }
+
+    // Transcribe each chunk and merge results
+    const allSegments: TranscriptionSegment[] = [];
+    const textParts: string[] = [];
+    let totalTranscribedDuration = 0;
+
+    try {
+      for (let i = 0; i < chunkPaths.length; i++) {
+        const offsetSec = i * chunkDuration;
+        const result = await this.transcribeSingle(chunkPaths[i]!, language);
+
+        textParts.push(result.text);
+        totalTranscribedDuration += result.durationSeconds;
+
+        // Offset segment timestamps by chunk start time
+        for (const seg of result.segments) {
+          allSegments.push({
+            start: seg.start + offsetSec,
+            end: seg.end + offsetSec,
+            text: seg.text,
+          });
+        }
+      }
+    } finally {
+      // Clean up chunk files
+      for (const chunkPath of chunkPaths) {
+        try { await unlink(chunkPath); } catch { /* ignore */ }
+      }
+    }
+
+    return {
+      text: textParts.join(" "),
+      segments: allSegments,
+      durationSeconds: totalTranscribedDuration,
     };
   }
 

--- a/packages/tools/src/media/config.ts
+++ b/packages/tools/src/media/config.ts
@@ -8,6 +8,8 @@ export interface MediaConfig {
   videoMaxHeight: number;
   audioBitrate: string;
   cookiesFile?: string;
+  downloadTimeoutMs: number;
+  extractionTimeoutMs: number;
 }
 
 export function getMediaConfig(): MediaConfig {
@@ -20,5 +22,7 @@ export function getMediaConfig(): MediaConfig {
     videoMaxHeight: parseInt(process.env["VIDEO_MAX_HEIGHT"] ?? "480", 10),
     audioBitrate: process.env["AUDIO_BITRATE"] ?? "128k",
     cookiesFile: process.env["YTDLP_COOKIES_FILE"],
+    downloadTimeoutMs: parseInt(process.env["YTDLP_TIMEOUT_MS"] ?? "600000", 10),
+    extractionTimeoutMs: parseInt(process.env["FFMPEG_TIMEOUT_MS"] ?? "300000", 10),
   };
 }

--- a/packages/tools/src/media/download.ts
+++ b/packages/tools/src/media/download.ts
@@ -14,6 +14,12 @@ const FALLBACK_PLAYER_CLIENTS = [
   "ios,web_creator",               // fallback 2: iOS + web_creator
 ];
 
+const AUTH_ERROR_PATTERNS = [
+  "Sign in to confirm you're not a bot",
+  "Sign in to confirm your age",
+  "This request was detected as a bot",
+];
+
 /** Copy cookies to a writable temp path so yt-dlp can save updates */
 async function getWritableCookiesArgs(config: MediaConfig): Promise<string[]> {
   if (!config.cookiesFile) return [];
@@ -27,11 +33,12 @@ async function baseArgs(config: MediaConfig): Promise<string[]> {
   return ["--js-runtimes", "node", ...(await getWritableCookiesArgs(config))];
 }
 
+/** Check both error.message and error.stderr (execFile puts output in stderr) */
 function isYouTubeAuthError(error: unknown): boolean {
   const msg = error instanceof Error ? error.message : String(error);
-  return msg.includes("Sign in to confirm you're not a bot")
-    || msg.includes("Sign in to confirm your age")
-    || msg.includes("This request was detected as a bot");
+  const stderr = (error as { stderr?: string }).stderr ?? "";
+  const combined = `${msg}\n${stderr}`;
+  return AUTH_ERROR_PATTERNS.some((p) => combined.includes(p));
 }
 
 function slugify(title: string): string {
@@ -81,16 +88,12 @@ export async function downloadVideo(opts: DownloadOptions): Promise<DownloadResu
     ];
 
     try {
-      await execFileAsync("yt-dlp", args, { timeout: 300_000 });
+      await execFileAsync("yt-dlp", args, { timeout: config.downloadTimeoutMs });
       const stats = await stat(outputPath);
       return { filePath: outputPath, fileSizeBytes: stats.size, format: ext as "mp3" | "mp4" };
     } catch (err) {
       lastError = err;
-      if (!isYouTubeAuthError(err) || !playerClient) {
-        // Not an auth error on a fallback attempt — keep trying fallbacks
-        // (on first attempt playerClient is undefined, so we always try next)
-        if (!isYouTubeAuthError(err)) throw err;
-      }
+      if (!isYouTubeAuthError(err)) throw err;
       // Auth error — try next player client
     }
   }

--- a/packages/tools/src/media/extract-audio.ts
+++ b/packages/tools/src/media/extract-audio.ts
@@ -9,6 +9,7 @@ export async function extractAudio(
   videoPath: string,
   audioPath: string,
   bitrate = "128k",
+  timeoutMs = 300_000,
 ): Promise<AudioExtractionResult> {
   const args = [
     "-i", videoPath,
@@ -19,7 +20,7 @@ export async function extractAudio(
     audioPath,
   ];
 
-  await execFileAsync("ffmpeg", args, { timeout: 120_000 });
+  await execFileAsync("ffmpeg", args, { timeout: timeoutMs });
 
   // Get duration from ffprobe
   const { stdout } = await execFileAsync("ffprobe", [

--- a/packages/tools/src/media/youtube-pipeline.ts
+++ b/packages/tools/src/media/youtube-pipeline.ts
@@ -87,7 +87,7 @@ export async function runYouTubePipeline(
     // Extract audio from video
     onProgress?.("extracting_audio");
     audioPath = videoPath.replace(/\.mp4$/, ".mp3");
-    const audioResult = await extractAudio(videoPath, audioPath, config.audioBitrate);
+    const audioResult = await extractAudio(videoPath, audioPath, config.audioBitrate, config.extractionTimeoutMs);
     audioSizeBytes = audioResult.fileSizeBytes;
     metadata.durationSeconds = audioResult.durationSeconds;
   } else {


### PR DESCRIPTION
- Fix isYouTubeAuthError to check error.stderr (Node's execFileAsync puts yt-dlp output there, not in error.message), which caused the fallback player client retry to never trigger
- Make download and extraction timeouts configurable via env vars (YTDLP_TIMEOUT_MS default 10min, FFMPEG_TIMEOUT_MS default 5min)
- Add chunked transcription in GroqWhisperClient: when audio exceeds 25MB, automatically split into chunks with ffmpeg, transcribe each, and merge segments with corrected timestamps

https://claude.ai/code/session_018AZ19gi3tzf6DyUJm9GYaj