### PR TITLE
Fix deploy script: clean untracked files before git pull

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 echo "==> Pulling latest code..."
+git clean -fd
+git checkout -- .
 git pull origin main
 
 echo "==> Building Docker image..."


### PR DESCRIPTION
The deploy was failing because an untracked .claude/tasks.md file on the
VPS conflicted with the incoming merge. Added git clean -fd and
git checkout -- . before pulling to ensure a clean working tree.

https://claude.ai/code/session_01NiFDtKXZigvLKBDV9cNhoJ