### PR TITLE
fix: write temp cookies to /tmp to avoid EACCES in container

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,7 +12,7 @@ services:
     volumes:
       - cherryagent-data:/home/node/.cherryagent
       - cherryagent-media:/opt/cherry-agent/media
-      - ./cookies.txt:/app/cookies.txt
+      - ./cookies.txt:/app/cookies.txt:ro
       - /home/sam/apps:/home/sam/apps
 
 networks:

--- a/packages/tools/src/media/download.ts
+++ b/packages/tools/src/media/download.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import { stat, mkdir, copyFile } from "node:fs/promises";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { promisify } from "node:util";
 import type { DownloadResult } from "./types.js";
 import type { MediaConfig } from "./config.js";
@@ -23,7 +24,7 @@ const AUTH_ERROR_PATTERNS = [
 /** Copy cookies to a writable temp path so yt-dlp can save updates */
 async function getWritableCookiesArgs(config: MediaConfig): Promise<string[]> {
   if (!config.cookiesFile) return [];
-  const tempCookies = join(config.mediaDir, ".cookies.tmp.txt");
+  const tempCookies = join(tmpdir(), ".cookies.tmp.txt");
   await copyFile(config.cookiesFile, tempCookies);
   return ["--cookies", tempCookies];
 }


### PR DESCRIPTION
The container runs as uid 1001 which may not have write access to the media directory volume. Use os.tmpdir() (/tmp) instead, which is always writable. Also mount cookies.txt as read-only since we only read from it.

https://claude.ai/code/session_01PiFttSWLQkF5rS9UFCgEvy