### PR TITLE
fix: handle EISDIR error when copying cookies to temp path

### DIFF
--- a/packages/tools/src/media/download.ts
+++ b/packages/tools/src/media/download.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { stat, mkdir, copyFile } from "node:fs/promises";
+import { stat, mkdir, copyFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { promisify } from "node:util";
@@ -25,6 +25,11 @@ const AUTH_ERROR_PATTERNS = [
 async function getWritableCookiesArgs(config: MediaConfig): Promise<string[]> {
   if (!config.cookiesFile) return [];
   const tempCookies = join(tmpdir(), ".cookies.tmp.txt");
+  // Remove stale directory at the target path to avoid EISDIR on copyFile
+  const destStat = await stat(tempCookies).catch(() => null);
+  if (destStat?.isDirectory()) {
+    await rm(tempCookies, { recursive: true });
+  }
   await copyFile(config.cookiesFile, tempCookies);
   return ["--cookies", tempCookies];
 }


### PR DESCRIPTION
If /tmp/.cookies.tmp.txt exists as a directory (stale state from another
process), copyFile fails with EISDIR. Check for and remove a conflicting
directory before copying.

https://claude.ai/code/session_01VQ1wFDRKtDqv9nxYGnmMwv