### PR TITLE
feat: Fitbit health summary endpoint for Claude integration

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -6,6 +6,7 @@ import { execFileSync } from "node:child_process";
 
 const PORT = parseInt(process.env["PORT"] ?? "3000", 10);
 const HOST = process.env["HOST"] ?? "0.0.0.0";
+const TIMEZONE = process.env["USER_TIMEZONE"] ?? "America/Toronto";
 
 function requireEnv(key: string): string {
   const value = process.env[key];
@@ -77,9 +78,10 @@ async function main() {
     }
   }
 
-  // Start Fastify (health + Fitbit OAuth + GitHub webhook)
+  // Start Fastify (health + Fitbit OAuth + Fitbit health summary + GitHub webhook)
   const server = await createServer({
     fitbitAuth,
+    timezone: TIMEZONE,
     githubWebhook: webhookSecret
       ? {
           repoMap,
@@ -100,7 +102,7 @@ async function main() {
   const botToken = requireEnv("TELEGRAM_BOT_TOKEN");
   const weeklyReportTimer = startWeeklyReport({
     fitbitAuth,
-    timezone: process.env.USER_TIMEZONE,
+    timezone: TIMEZONE,
     sendMessage: async (html) => {
       await fetch(
         `https://api.telegram.org/bot${botToken}/sendMessage`,

--- a/packages/api/src/routes/fitbit-health-summary.ts
+++ b/packages/api/src/routes/fitbit-health-summary.ts
@@ -1,0 +1,40 @@
+import type { FastifyInstance } from "fastify";
+import type { FitbitAuth } from "@cherryagent/tools";
+import { getFitbitHealthSummary } from "@cherryagent/tools";
+
+const INTERNAL_TOKEN = process.env["INTERNAL_API_TOKEN"] ?? "";
+
+export function fitbitHealthSummaryRoute(
+  fitbitAuth: FitbitAuth,
+  timezone: string,
+) {
+  return async function (app: FastifyInstance) {
+    app.get("/api/fitbit/health-summary", async (req, reply) => {
+      const token = req.headers["x-internal-token"];
+      if (!INTERNAL_TOKEN || token !== INTERNAL_TOKEN) {
+        return reply.status(401).send({ error: "unauthorized" });
+      }
+
+      const { date = "today" } = req.query as { date?: string };
+
+      try {
+        const summary = await getFitbitHealthSummary(fitbitAuth, date, timezone);
+        return reply.send(summary);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Unknown error";
+
+        if (
+          message.includes("not authorized") ||
+          message.includes("authorization expired")
+        ) {
+          return reply
+            .status(503)
+            .send({ error: "fitbit_unauthorized", detail: message });
+        }
+
+        req.log.error({ err }, "Fitbit health summary failed");
+        return reply.status(500).send({ error: "internal_error", detail: message });
+      }
+    });
+  };
+}

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -1,11 +1,13 @@
 import Fastify from "fastify";
 import { healthRoutes } from "./routes/health.js";
 import { fitbitCallbackRoute } from "./routes/fitbit-callback.js";
+import { fitbitHealthSummaryRoute } from "./routes/fitbit-health-summary.js";
 import { githubWebhookRoute } from "./routes/github-webhook.js";
 import type { FitbitAuth, GitSyncResult } from "@cherryagent/tools";
 
 interface ServerDeps {
   fitbitAuth?: FitbitAuth;
+  timezone?: string;
   githubWebhook?: {
     repoMap: Map<string, string>;
     webhookSecret: string;
@@ -24,6 +26,12 @@ export async function createServer(deps?: ServerDeps) {
 
   if (deps?.fitbitAuth) {
     await app.register(fitbitCallbackRoute(deps.fitbitAuth));
+    await app.register(
+      fitbitHealthSummaryRoute(
+        deps.fitbitAuth,
+        deps.timezone ?? "America/Toronto",
+      ),
+    );
   }
 
   if (deps?.githubWebhook) {

--- a/packages/tools/src/fitbit/auth.ts
+++ b/packages/tools/src/fitbit/auth.ts
@@ -37,7 +37,7 @@ export class FitbitAuth {
       response_type: "code",
       client_id: this.clientId,
       redirect_uri: this.redirectUri,
-      scope: "nutrition",
+      scope: "activity heartrate nutrition sleep weight",
       expires_in: "604800",
     });
     return `https://www.fitbit.com/oauth2/authorize?${params.toString()}`;

--- a/packages/tools/src/fitbit/health-summary.ts
+++ b/packages/tools/src/fitbit/health-summary.ts
@@ -1,0 +1,170 @@
+import type { FitbitAuth } from "./auth.js";
+
+export interface FitbitHealthSummary {
+  date: string;
+  activity: {
+    steps: number;
+    caloriesOut: number;
+    activeMinutes: number; // fairly + very active combined
+  };
+  nutrition: {
+    caloriesIn: number;
+    protein: number; // grams
+    carbs: number;   // grams
+    fat: number;     // grams
+    deficit: number; // caloriesOut - caloriesIn (positive = deficit)
+  };
+  sleep: {
+    durationMinutes: number;
+    efficiency: number; // percentage 0-100
+    startTime: string | null;
+  };
+  heart: {
+    restingHeartRate: number | null;
+  };
+  weight: {
+    kg: number | null;
+    lastLoggedDate: string | null;
+  };
+}
+
+async function fitbitGet(
+  token: string,
+  path: string,
+): Promise<unknown> {
+  const res = await fetch(`https://api.fitbit.com${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    throw new Error(`Fitbit API error ${res.status} for ${path}`);
+  }
+  return res.json();
+}
+
+export async function getFitbitHealthSummary(
+  auth: FitbitAuth,
+  date: string,
+  timezone = "America/Toronto",
+): Promise<FitbitHealthSummary> {
+  const token = await auth.getAccessToken();
+
+  // Resolve "today" to a real date string in the user's timezone
+  const resolvedDate =
+    date === "today"
+      ? new Date().toLocaleDateString("en-CA", { timeZone: timezone })
+      : date;
+
+  const [activityRaw, nutritionRaw, sleepRaw, heartRaw, weightRaw] =
+    await Promise.allSettled([
+      fitbitGet(token, `/1/user/-/activities/date/${resolvedDate}.json`),
+      fitbitGet(token, `/1/user/-/foods/log/date/${resolvedDate}.json`),
+      fitbitGet(token, `/1/user/-/sleep/date/${resolvedDate}.json`),
+      fitbitGet(
+        token,
+        `/1/user/-/activities/heart/date/${resolvedDate}/1d.json`,
+      ),
+      fitbitGet(token, `/1/user/-/body/log/weight/date/${resolvedDate}.json`),
+    ]);
+
+  // --- Activity ---
+  let steps = 0;
+  let caloriesOut = 0;
+  let activeMinutes = 0;
+  if (activityRaw.status === "fulfilled") {
+    const a = activityRaw.value as {
+      summary?: {
+        steps?: number;
+        caloriesOut?: number;
+        fairlyActiveMinutes?: number;
+        veryActiveMinutes?: number;
+      };
+    };
+    steps = a.summary?.steps ?? 0;
+    caloriesOut = a.summary?.caloriesOut ?? 0;
+    activeMinutes =
+      (a.summary?.fairlyActiveMinutes ?? 0) +
+      (a.summary?.veryActiveMinutes ?? 0);
+  }
+
+  // --- Nutrition ---
+  let caloriesIn = 0;
+  let protein = 0;
+  let carbs = 0;
+  let fat = 0;
+  if (nutritionRaw.status === "fulfilled") {
+    const n = nutritionRaw.value as {
+      summary?: {
+        calories?: number;
+        protein?: number;
+        carbs?: number;
+        fat?: number;
+      };
+    };
+    caloriesIn = n.summary?.calories ?? 0;
+    protein = n.summary?.protein ?? 0;
+    carbs = n.summary?.carbs ?? 0;
+    fat = n.summary?.fat ?? 0;
+  }
+
+  // --- Sleep ---
+  let durationMinutes = 0;
+  let efficiency = 0;
+  let sleepStartTime: string | null = null;
+  if (sleepRaw.status === "fulfilled") {
+    const s = sleepRaw.value as {
+      summary?: { totalMinutesAsleep?: number };
+      sleep?: Array<{
+        isMainSleep?: boolean;
+        efficiency?: number;
+        startTime?: string;
+      }>;
+    };
+    durationMinutes = s.summary?.totalMinutesAsleep ?? 0;
+    const mainSleep = s.sleep?.find((e) => e.isMainSleep) ?? s.sleep?.[0];
+    efficiency = mainSleep?.efficiency ?? 0;
+    sleepStartTime = mainSleep?.startTime ?? null;
+  }
+
+  // --- Heart rate ---
+  let restingHeartRate: number | null = null;
+  if (heartRaw.status === "fulfilled") {
+    const h = heartRaw.value as {
+      "activities-heart"?: Array<{
+        value?: { restingHeartRate?: number };
+      }>;
+    };
+    restingHeartRate =
+      h["activities-heart"]?.[0]?.value?.restingHeartRate ?? null;
+  }
+
+  // --- Weight ---
+  let weightKg: number | null = null;
+  let lastLoggedDate: string | null = null;
+  if (weightRaw.status === "fulfilled") {
+    const w = weightRaw.value as {
+      weight?: Array<{ weight?: number; date?: string }>;
+    };
+    const latest = w.weight?.[w.weight.length - 1];
+    weightKg = latest?.weight ?? null;
+    lastLoggedDate = latest?.date ?? null;
+  }
+
+  return {
+    date: resolvedDate,
+    activity: { steps, caloriesOut, activeMinutes },
+    nutrition: {
+      caloriesIn,
+      protein,
+      carbs,
+      fat,
+      deficit: caloriesOut - caloriesIn,
+    },
+    sleep: {
+      durationMinutes,
+      efficiency,
+      startTime: sleepStartTime,
+    },
+    heart: { restingHeartRate },
+    weight: { kg: weightKg, lastLoggedDate },
+  };
+}

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -30,6 +30,8 @@ export { FitbitFoodLogReader } from "./fitbit/food-log-reader.js";
 export type { DailySummary, WeeklySummary } from "./fitbit/food-log-reader.js";
 export { formatOnDemandReport, formatWeeklyReport } from "./fitbit/sat-fat-report.js";
 export { startWeeklyReport } from "./fitbit/weekly-scheduler.js";
+export { getFitbitHealthSummary } from "./fitbit/health-summary.js";
+export type { FitbitHealthSummary } from "./fitbit/health-summary.js";
 
 // Cost
 export type { CostEntry } from "./cost/cost-tracker.js";


### PR DESCRIPTION
## What

Exposes a new internal Fastify endpoint that returns a daily Fitbit health snapshot, enabling Claude to read real fitness data via the MCP layer.

## Changes

- **** — Expanded OAuth scope from  to 
- **** *(new)* — Calls 5 Fitbit API endpoints in parallel (activity, food log, sleep, heart rate, weight) and returns a unified  object. All fields degrade gracefully to  if data is missing.
- **** — Exports  and  type
- **** *(new)* — . Protected by  header. Returns  on Fitbit auth errors so the MCP layer can surface an actionable message.
- **** — Registers the new route; adds  to 
- **** — Passes  into 

## Required after merge + deploy

1. Add  to  — generate with 
2. Restart container
3. **Run  in Telegram** — existing tokens only have  scope; re-auth is required for the new scopes

## New env vars

| Var | Required | Notes |
|---|---|---|
|  | Yes | Shared secret for internal route. Same value goes in vps-mcp-server. |


---
_Created by Claude via sam-vps MCP_